### PR TITLE
LDFLAGS is needed in make

### DIFF
--- a/recipes/io_lib/1.14.11/build.sh
+++ b/recipes/io_lib/1.14.11/build.sh
@@ -8,8 +8,7 @@ n="$CPU_COUNT"
   --prefix="$PREFIX" \
   --with-zlib="$PREFIX" \
   --with-libcurl="$PREFIX" \
-  CPPFLAGS="-I$PREFIX/include" \
-  LDFLAGS="-Wl,-rpath-link,$PREFIX/lib -Wl,--disable-new-dtags -L$PREFIX/lib"
+  CPPFLAGS="-I$PREFIX/include"
 
-make -j "$n"
+make -j "$n" LDFLAGS="-Wl,-rpath-link,$PREFIX/lib -Wl,--disable-new-dtags -L$PREFIX/lib"
 make install

--- a/recipes/io_lib/1.14.9/build.sh
+++ b/recipes/io_lib/1.14.9/build.sh
@@ -8,8 +8,7 @@ n="$CPU_COUNT"
   --prefix="$PREFIX" \
   --with-zlib="$PREFIX" \
   --with-libcurl="$PREFIX" \
-  CPPFLAGS="-I$PREFIX/include" \
-  LDFLAGS="-Wl,-rpath-link,$PREFIX/lib -Wl,--disable-new-dtags -L$PREFIX/lib"
+  CPPFLAGS="-I$PREFIX/include"
 
-make -j "$n"
+make -j "$n" LDFLAGS="-Wl,-rpath-link,$PREFIX/lib -Wl,--disable-new-dtags -L$PREFIX/lib"
 make install


### PR DESCRIPTION
Previous PR has a problem. LDFLAGS need to be passed to make directly. Passing them to configure does not work.