### PR TITLE
pin bam_stats/1.13.0 to htslib 1.9

### DIFF
--- a/recipes/bam_stats/1.13.0/meta.yaml
+++ b/recipes/bam_stats/1.13.0/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "1.13.0" %}
+{% set htslib_version = "1.9" %}
 
 package:
   name: bam_stats
@@ -10,7 +11,7 @@ about:
   summary: "Legacy, see cancerit/PCAP-core: NGS reference implementations and helper code for the IGCG/TCGA Pan-Cancer Analysis Project."
 
 build:
-  number: 1
+  number: 2
   
 source:
   git_url: https://github.com/ICGC-TCGA-PanCancer/PCAP-core.git
@@ -23,9 +24,9 @@ requirements:
     - {{ compiler("c") }}
     - make
   host:
-    - libhts-dev
+    - libhts-dev =={{ htslib_version }}
   run:
-    - libhts
+    - libhts =={{ htslib_version }}
 
 test:
   commands:


### PR DESCRIPTION
Else when we create a develop versions of samtools the ABI may differ between build time htslib and latest htslib available on installing.